### PR TITLE
Use device timestamp for communication

### DIFF
--- a/mirobo/vacuum.py
+++ b/mirobo/vacuum.py
@@ -137,6 +137,7 @@ class Vacuum:
             return m.data.value["result"]
         except Exception as ex:
             _LOGGER.error("got error when receiving: %s" % ex)
+            self.__enter__()
             raise
 
     def start(self):

--- a/mirobo/vacuum.py
+++ b/mirobo/vacuum.py
@@ -93,6 +93,7 @@ class Vacuum:
         delta_ts = int(time.mktime(datetime.datetime.utcnow().timetuple())) - self._ts_server
         if self._devtype is None or self._serial is None or (delta_ts > 120):
             self.__enter__()  # when called outside of cm, initialize.
+            delta_ts = int(time.mktime(datetime.datetime.utcnow().timetuple())) - self._ts_server
 
         cmd = {
             "id": self._id,


### PR DESCRIPTION
Hi Rytilahti

Thank you for your brilliant work on miio.

I want to use your code to control some other Xiaomi devices. 
But I found some xiaomi devices time stamp is not sync with network, it reset to zero when device power-off.
So when using your code to send message to those device will got recv timeout.

I pushed this patch, this patch will set message time stamp according to device time stamp. And increase time stamp when send next message.

This can work on vacumm device too.

May you merge this commit to your code and release to PIP?