### PR TITLE
Fix Home Assistant link to doc, using new `vacuum` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,4 @@ Clean #1: 2017-03-05 16:17:52-2017-03-05 17:14:59 (complete: False, unknown: 0)
 
 # Home Assistant support
 
-See [Xiaomi Mi Robot Vacuum](https://home-assistant.io/components/switch.xiaomi_vacuum/).
-
+See [Xiaomi Mi Robot Vacuum](https://home-assistant.io/components/vacuum.xiaomi/).


### PR DESCRIPTION
Change the link to https://home-assistant.io/components/vacuum.xiaomi/