### PR TITLE
Device support for the Chuangmi IR Remote Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Thanks for the nice people over [ioBroker forum](http://forum.iobroker.net/viewt
 * Xiaomi Philips Eyecare Smart Lamp 2
 * Xiaomi Philips LED Ceiling Lamp
 * Xiaomi Philips LED Ball Lamp
+* Xiaomi Universal IR Remote Controller (Chuangmi IR)
 
 ### Adding support for other devices
 

--- a/mirobo/__init__.py
+++ b/mirobo/__init__.py
@@ -8,5 +8,6 @@ from mirobo.airpurifier import AirPurifier
 from mirobo.strip import Strip
 from mirobo.ceil import Ceil
 from mirobo.philips_eyecare import PhilipsEyecare
+from mirobo.chuangmi_ir import ChuangmiIr
 from mirobo.device import Device, DeviceException
 from mirobo.discovery import Discovery

--- a/mirobo/chuangmi_ir.py
+++ b/mirobo/chuangmi_ir.py
@@ -1,0 +1,21 @@
+from .device import Device
+
+class ChuangmiIr(Device):
+    """Main class representing Chuangmi IR Remote Controller."""
+
+    def learn(self, key: int):
+        """Learn a infrared command."""
+
+        # The key is a storage slot. The value must be between 1 and 1000000
+        return self.send("miIO.ir_learn", {'key': str(key)})
+
+    def read(self, key: int):
+        """Read a learned command."""
+        return self.send("miIO.ir_read", {'key': str(key)})
+
+    def play(self, command: string, frequency: int):
+        """Play a captured command."""
+        if frequency is None:
+            frequency = 38400
+        return self.send("miIO.ir_play",
+                         {'freq': frequency, 'code': str(command)})

--- a/mirobo/chuangmi_ir.py
+++ b/mirobo/chuangmi_ir.py
@@ -1,5 +1,6 @@
 from .device import Device
 
+
 class ChuangmiIr(Device):
     """Main class representing Chuangmi IR Remote Controller."""
 
@@ -13,9 +14,9 @@ class ChuangmiIr(Device):
         """Read a learned command."""
         return self.send("miIO.ir_read", {'key': str(key)})
 
-    def play(self, command: string, frequency: int):
+    def play(self, command: str, frequency: int):
         """Play a captured command."""
         if frequency is None:
             frequency = 38400
         return self.send("miIO.ir_play",
-                         {'freq': frequency, 'code': str(command)})
+                         {'freq': frequency, 'code': command})


### PR DESCRIPTION

The command set is based on an [unofficial home assistant component](https://github.com/syssi/chuangmi_ir/blob/master/custom_components/switch/chuangmi_ir.py) was discussed [here](https://community.home-assistant.io/t/xiaomi-chuangmi-ir-universal-ir-remote-controller/25821) and applies to this [product](https://www.gearbest.com/smart-home/pp_229556.html).