### PR TITLE
Power strip: Fixes calculation of the instantaneous current

### DIFF
--- a/mirobo/plug.py
+++ b/mirobo/plug.py
@@ -20,14 +20,17 @@ class PlugStatus:
         return self.data["temperature"]
 
     @property
-    def current(self) -> float:
-        return self.data["current"]
+    def load_power(self) -> float:
+        if self.data["current"] is not None:
+            # The constant of 110V is used intentionally. The current was
+            # calculated with a wrong reference voltage already.
+            return self.data["current"] * 110
 
     def __str__(self) -> str:
-        s = "<PlugStatus power=%s, temperature=%s, current=%s>" % \
+        s = "<PlugStatus power=%s, temperature=%s, load_power=%s>" % \
             (self.power,
              self.temperature,
-             self.current)
+             self.load_power)
         return s
 
 


### PR DESCRIPTION
The value of the property "current" is misleading for countries with 230V mains because it was calculated with a wrong reference voltage (110V). As workaround a calculated property "load_power" is provided now. It's a firmware issue of the Xiaomi strip.