### PR TITLE
Add miio-extract-tokens tool for extracting tokens from sqlite databases

### DIFF
--- a/mirobo/extract_tokens.py
+++ b/mirobo/extract_tokens.py
@@ -2,13 +2,14 @@ import click
 import tarfile
 import tempfile
 import sqlite3
-import binascii
 from Crypto.Cipher import AES
 from pprint import pformat as pf
+
 
 def dump_raw(dev):
     raw = {k: dev[k] for k in dev.keys()}
     click.echo(pf(raw))
+
 
 def decrypt_ztoken(ztoken):
     if len(ztoken) <= 32:
@@ -46,11 +47,13 @@ def read_android(conn):
         token = dev['token']
         click.echo("%s (%s) at %s. token: %s (mac: %s, ssid: %s)" % (name, model, ip, token, mac, ssid))
 
+
 def write(db, fp):
     fp.open()
     db.seek(0)  # go to the beginning
     click.echo("Saving db to %s" % fp)
     fp.write(db.read())
+
 
 def read_tokens(db):
     conn = sqlite3.connect(db)

--- a/mirobo/extract_tokens.py
+++ b/mirobo/extract_tokens.py
@@ -1,0 +1,96 @@
+import click
+import tarfile
+import tempfile
+import sqlite3
+import binascii
+from Crypto.Cipher import AES
+from pprint import pformat as pf
+
+def dump_raw(dev):
+    raw = {k: dev[k] for k in dev.keys()}
+    click.echo(pf(raw))
+
+def decrypt_ztoken(ztoken):
+    if len(ztoken) <= 32:
+        return ztoken
+
+    keystring = '00000000000000000000000000000000'
+    key = bytes.fromhex(keystring)
+    cipher = AES.new(key, AES.MODE_ECB)
+    token = cipher.decrypt(bytes.fromhex(ztoken[:64]))
+
+    return token
+
+
+def read_apple(conn):
+    click.echo("Reading tokens from Apple DB")
+    c = conn.execute("SELECT * FROM ZDEVICE WHERE ZTOKEN IS NOT '';")
+    for dev in c.fetchall():
+        token = decrypt_ztoken(dev['ZTOKEN'])
+        ip = dev['ZLOCALIP']
+        click.echo("device at %s. token: %s" % (ip, token))
+        dump_raw(dev)
+    raise NotImplementedError("Please report the previous output to developers")
+
+
+def read_android(conn):
+    click.echo("Reading tokens from Android DB")
+    c = conn.execute("SELECT * FROM devicerecord WHERE token IS NOT '';")
+    for dev in c.fetchall():
+        # dump_raw(dev)
+        ip = dev['localIP']
+        mac = dev['mac']
+        model = dev['model']
+        name = dev['name']
+        ssid = dev['ssid']
+        token = dev['token']
+        click.echo("%s (%s) at %s. token: %s (mac: %s, ssid: %s)" % (name, model, ip, token, mac, ssid))
+
+def write(db, fp):
+    fp.open()
+    db.seek(0)  # go to the beginning
+    click.echo("Saving db to %s" % fp)
+    fp.write(db.read())
+
+def read_tokens(db):
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    with conn:
+        is_android = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='devicerecord';").fetchone() is not None
+        is_apple = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='ZDEVICE'").fetchone() is not None
+        if is_android:
+            read_android(conn)
+        elif is_apple:
+            read_apple(conn)
+        else:
+            click.echo("Error, unknown database type!")
+
+
+@click.command()
+@click.argument('backup')
+@click.option('--write-to-disk', type=click.File('wb'), help='writes sqlite3 db to a file for debugging')
+def main(backup, write_to_disk):
+    """Reads device information out from an sqlite3 DB.
+     If the given file is a .tar file, the file will be extracted
+     and the database automatically located (out of Android backups).
+    """
+    if backup.endswith(".tar"):
+        DBFILE = "apps/com.xiaomi.smarthome/db/miio2.db"
+        with tarfile.open(backup) as f:
+            click.echo("Opened %s" % backup)
+            db = f.extractfile(DBFILE)
+            with tempfile.NamedTemporaryFile() as fp:
+                click.echo("Extracting to %s" % fp.name)
+                fp.write(db.read())
+                if write_to_disk:
+                    write(db, write_to_disk)
+
+                read_tokens(fp.name)
+    else:
+        read_tokens(backup)
+
+
+if __name__ == "__main__":
+    main()

--- a/mirobo/extract_tokens.py
+++ b/mirobo/extract_tokens.py
@@ -6,79 +6,90 @@ from Crypto.Cipher import AES
 from pprint import pformat as pf
 
 
-def dump_raw(dev):
-    raw = {k: dev[k] for k in dev.keys()}
-    click.echo(pf(raw))
+class BackupDatabaseReader:
+    def __init__(self, dump_all=False, dump_raw=False):
+        self.dump_all = dump_all
+        self.dump_raw = dump_raw
 
+    @staticmethod
+    def dump_raw(dev):
+        raw = {k: dev[k] for k in dev.keys()}
+        click.echo(pf(raw))
 
-def decrypt_ztoken(ztoken):
-    if len(ztoken) <= 32:
-        return ztoken
+    @staticmethod
+    def decrypt_ztoken(ztoken):
+        if len(ztoken) <= 32:
+            return ztoken
 
-    keystring = '00000000000000000000000000000000'
-    key = bytes.fromhex(keystring)
-    cipher = AES.new(key, AES.MODE_ECB)
-    token = cipher.decrypt(bytes.fromhex(ztoken[:64]))
+        keystring = '00000000000000000000000000000000'
+        key = bytes.fromhex(keystring)
+        cipher = AES.new(key, AES.MODE_ECB)
+        token = cipher.decrypt(bytes.fromhex(ztoken[:64]))
 
-    return token
+        return token.decode()
 
+    def read_apple(self):
+        click.echo("Reading tokens from Apple DB")
+        c = self.conn.execute("SELECT * FROM ZDEVICE WHERE ZTOKEN IS NOT '';")
+        for dev in c.fetchall():
+            if self.dump_raw:
+                BackupDatabaseReader.dump_raw(dev)
+            ip = dev['ZLOCALIP']
+            mac = dev['ZMAC']
+            model = dev['ZMODEL']
+            name = dev['ZNAME']
+            token = BackupDatabaseReader.decrypt_ztoken(dev['ZTOKEN'])
+            if ip or self.dump_all:
+                click.echo("%s\n\tModel: %s\n\tIP address: %s\n\tToken: %s\n\tMAC: %s" % (name, model, ip, token, mac))
 
-def read_apple(conn):
-    click.echo("Reading tokens from Apple DB")
-    c = conn.execute("SELECT * FROM ZDEVICE WHERE ZTOKEN IS NOT '';")
-    for dev in c.fetchall():
-        token = decrypt_ztoken(dev['ZTOKEN'])
-        ip = dev['ZLOCALIP']
-        click.echo("device at %s. token: %s" % (ip, token))
-        dump_raw(dev)
-    raise NotImplementedError("Please report the previous output to developers")
+    def read_android(self):
+        click.echo("Reading tokens from Android DB")
+        c = self.conn.execute("SELECT * FROM devicerecord WHERE token IS NOT '';")
+        for dev in c.fetchall():
+            if self.dump_raw:
+                BackupDatabaseReader.dump_raw(dev)
+            ip = dev['localIP']
+            mac = dev['mac']
+            model = dev['model']
+            name = dev['name']
+            token = dev['token']
+            if ip or self.dump_all:
+                click.echo("%s\n\tModel: %s\n\tIP address: %s\n\tToken: %s\n\tMAC: %s" % (name, model, ip, token, mac))
 
+    def dump_to_file(self, fp):
+        fp.open()
+        self.db.seek(0)  # go to the beginning
+        click.echo("Saving db to %s" % fp)
+        fp.write(self.db.read())
 
-def read_android(conn):
-    click.echo("Reading tokens from Android DB")
-    c = conn.execute("SELECT * FROM devicerecord WHERE token IS NOT '';")
-    for dev in c.fetchall():
-        # dump_raw(dev)
-        ip = dev['localIP']
-        mac = dev['mac']
-        model = dev['model']
-        name = dev['name']
-        ssid = dev['ssid']
-        token = dev['token']
-        click.echo("%s (%s) at %s. token: %s (mac: %s, ssid: %s)" % (name, model, ip, token, mac, ssid))
-
-
-def write(db, fp):
-    fp.open()
-    db.seek(0)  # go to the beginning
-    click.echo("Saving db to %s" % fp)
-    fp.write(db.read())
-
-
-def read_tokens(db):
-    conn = sqlite3.connect(db)
-    conn.row_factory = sqlite3.Row
-    with conn:
-        is_android = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='devicerecord';").fetchone() is not None
-        is_apple = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='ZDEVICE'").fetchone() is not None
-        if is_android:
-            read_android(conn)
-        elif is_apple:
-            read_apple(conn)
-        else:
-            click.echo("Error, unknown database type!")
+    def read_tokens(self, db):
+        self.db = db
+        self.conn = sqlite3.connect(db)
+        self.conn.row_factory = sqlite3.Row
+        with self.conn:
+            is_android = self.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='devicerecord';").fetchone() is not None
+            is_apple = self.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='ZDEVICE'").fetchone() is not None
+            if is_android:
+                self.read_android()
+            elif is_apple:
+                self.read_apple()
+            else:
+                click.echo("Error, unknown database type!")
 
 
 @click.command()
 @click.argument('backup')
 @click.option('--write-to-disk', type=click.File('wb'), help='writes sqlite3 db to a file for debugging')
-def main(backup, write_to_disk):
+@click.option('--dump-all', is_flag=True, default=False, help='dump devices without ip addresses')
+@click.option('--dump-raw', is_flag=True, help='dumps raw rows')
+def main(backup, write_to_disk, dump_all, dump_raw):
     """Reads device information out from an sqlite3 DB.
      If the given file is a .tar file, the file will be extracted
      and the database automatically located (out of Android backups).
     """
+    reader = BackupDatabaseReader(dump_all, dump_raw)
     if backup.endswith(".tar"):
         DBFILE = "apps/com.xiaomi.smarthome/db/miio2.db"
         with tarfile.open(backup) as f:
@@ -88,11 +99,11 @@ def main(backup, write_to_disk):
                 click.echo("Extracting to %s" % fp.name)
                 fp.write(db.read())
                 if write_to_disk:
-                    write(db, write_to_disk)
+                    reader.dump_to_file(write_to_disk)
 
-                read_tokens(fp.name)
+                reader.read_tokens(fp.name)
     else:
-        read_tokens(backup)
+        reader.read_tokens(backup)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
             'mirobo=mirobo.vacuum_cli:cli',
             'miplug=mirobo.plug_cli:cli',
             'miceil=mirobo.ceil_cli:cli',
-            'mieye=mirobo.philips_eyecare_cli:cli'
+            'mieye=mirobo.philips_eyecare_cli:cli',
+            'miio-extract-tokens=mirobo.extract_tokens:main'
         ],
     },
 )


### PR DESCRIPTION
This is to simplify the process for token and device type extraction,
and will probably later merged to the CLI tool to generate config files
based on known devices.

Tested to work fine on .tar files extracted from Android backups
as well as sqlite DBs from both Android and Apple. Related to #75.

Example output:
```
± miio-extract-tokens backup/backup.tar
Opened backup/backup.tar
Extracting to /tmp/tmpqvfj2l1x
Reading tokens from Android DB
Gateway (lumi.gateway.v3) at 192.168.XXX. token: 91c52a27eff00b95XX (mac: 28:6C:07:XX, ssid: XXX)
room1 (yeelink.light.color1) at 192.168.XXX. token: a37905aa9a587faXX (mac: F0:B4:29:XX, ssid: XXX)
room2 (yeelink.light.color1) at 192.168.XXX. token: 86b130eac015b2bd2dXX (mac: 28:6C:07:XX, ssid: XXX)
Flower Care (hhcc.plantmonitor.v1) at 134.XXX.XXX. token: 124f90d87b4b9XX (mac: C4:7C:8D:XX, ssid: )
Mi Robot Vacuum (rockrobo.vacuum.v1) at 192.168.XXX. token: 476e6b70343055XXX (mac: 28:6C:07:XX, ssid: XXX)
```