### PR TITLE
Implement adding, deleting and updating the timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ $ mirobo timer add --cron '* * * * *'
 Activating/deactivating an existing timer,
 use `mirobo timer` to get the required id.
 ```
-$ mirobo timer update <id> [--off|--on]
+$ mirobo timer update <id> [--enable|--disable]
 ```
 
 Deleting a timer

--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ Timer #6, id 1488667697356 (ts: 2017-03-04 23:48:17.355999)
   At 08:48 on the 5th of March
 ```
 
+Adding a new timer
+```
+$ mirobo timer add --cron '* * * * *'
+```
+
+Activating/deactivating an existing timer,
+use `mirobo timer` to get the required id.
+```
+$ mirobo timer update <id> [--off|--on]
+```
+
+Deleting a timer
+```
+$ mirobo timer delete <id>
+```
+
 ### Cleaning history
 
 ```

--- a/mirobo/vacuum.py
+++ b/mirobo/vacuum.py
@@ -139,13 +139,18 @@ class Vacuum(Device):
 
         return timers
 
-    def set_timer(self, details):
-        # how to create timers/change values?
-        # ['ts', 'on'] to enable
-        raise NotImplementedError()
-        # return self.send(
-        #     "set_timer", [["ts", ["cron_line", ["start_clean", ""]]]])
-        # return self.send("upd_timer", ["ts", "on"])
+    def add_timer(self, cron, command, parameters):
+        import time
+        ts = int(round(time.time() * 1000))
+        return self.send("set_timer", [[str(ts), [cron, [command, parameters]]]])
+
+    def delete_timer(self, timer_id: int):
+        return self.send("del_timer", [str(timer_id)])
+
+    def update_timer(self, timer_id: int, mode):
+        if mode != "on" and mode != "off":
+            raise DeviceException("update_timer needs to be either 'on' or 'off")
+        return self.send("upd_timer", [str(timer_id), mode])
 
     def dnd_status(self):
         """Returns do-not-disturb status."""

--- a/mirobo/vacuum.py
+++ b/mirobo/vacuum.py
@@ -2,6 +2,7 @@ import logging
 import math
 import time
 from typing import List
+import enum
 
 from .vacuumcontainers import (VacuumStatus, ConsumableStatus,
                                CleaningSummary, CleaningDetails, Timer)
@@ -13,6 +14,10 @@ _LOGGER = logging.getLogger(__name__)
 class VacuumException(DeviceException):
     pass
 
+
+class TimerState(enum.Enum):
+    On = "on"
+    Off = "off"
 
 class Vacuum(Device):
     """Main class representing the vacuum."""
@@ -139,7 +144,8 @@ class Vacuum(Device):
 
         return timers
 
-    def add_timer(self, cron, command, parameters):
+    def add_timer(self, cron: str, command: str, parameters: str):
+        """Add a timer."""
         import time
         ts = int(round(time.time() * 1000))
         return self.send("set_timer", [
@@ -147,12 +153,13 @@ class Vacuum(Device):
         ])
 
     def delete_timer(self, timer_id: int):
+        """Delete a timer."""
         return self.send("del_timer", [str(timer_id)])
 
-    def update_timer(self, timer_id: int, mode):
-        if mode != "on" and mode != "off":
-            raise DeviceException("'on' or 'off are only allowed")
-        return self.send("upd_timer", [str(timer_id), mode])
+    def update_timer(self, timer_id: int, mode: TimerState):
+        if mode != TimerState.On and mode != TimerState.Off:
+            raise DeviceException("Only 'On' or 'Off' are  allowed")
+        return self.send("upd_timer", [str(timer_id), mode.value])
 
     def dnd_status(self):
         """Returns do-not-disturb status."""

--- a/mirobo/vacuum.py
+++ b/mirobo/vacuum.py
@@ -142,14 +142,16 @@ class Vacuum(Device):
     def add_timer(self, cron, command, parameters):
         import time
         ts = int(round(time.time() * 1000))
-        return self.send("set_timer", [[str(ts), [cron, [command, parameters]]]])
+        return self.send("set_timer", [
+            [str(ts), [cron, [command, parameters]]]
+        ])
 
     def delete_timer(self, timer_id: int):
         return self.send("del_timer", [str(timer_id)])
 
     def update_timer(self, timer_id: int, mode):
         if mode != "on" and mode != "off":
-            raise DeviceException("update_timer needs to be either 'on' or 'off")
+            raise DeviceException("'on' or 'off are only allowed")
         return self.send("upd_timer", [str(timer_id), mode])
 
     def dnd_status(self):

--- a/mirobo/vacuum_cli.py
+++ b/mirobo/vacuum_cli.py
@@ -344,7 +344,7 @@ def update(vac: mirobo.Vacuum, timer_id, enable, disable):
     elif disable and not enable:
         vac.update_timer(timer_id, TimerState.Off)
     else:
-        click.echo("Only 'on' and 'off' are valid for timer")
+        click.echo("You need to specify either --enable or --disable")
 
 
 @cli.command()


### PR DESCRIPTION
New commands are:
  * mirobo timer add --cron <cron string> --command <command> --params <params>
  * mirobo timer delete <id>
  * mirobo timer update [--on|--off] <id>

Although the vacuum accepts command and params, the added cron entry will be just 'start_clean'